### PR TITLE
Fixed Bug Causing Url to Fail to Update

### DIFF
--- a/mobile/VotingApp/VotingApp.Android/Properties/AndroidManifest.xml
+++ b/mobile/VotingApp/VotingApp.Android/Properties/AndroidManifest.xml
@@ -2,5 +2,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.minnick.votingapp">
 	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="28" />
 	<uses-permission android:name="android.permission.INTERNET" />
-	<application android:label="VotingApp.Android"></application>
+	<application android:label="Voting App"></application>
 </manifest>

--- a/mobile/VotingApp/VotingApp.Android/VotingApp.Android.csproj
+++ b/mobile/VotingApp/VotingApp.Android/VotingApp.Android.csproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Xamarin.Forms.3.4.0.1009999\build\Xamarin.Forms.props" Condition="Exists('..\packages\Xamarin.Forms.3.4.0.1009999\build\Xamarin.Forms.props')" />
+  <Import Project="..\packages\Xamarin.Forms.3.4.0.1029999\build\Xamarin.Forms.props" Condition="Exists('..\packages\Xamarin.Forms.3.4.0.1029999\build\Xamarin.Forms.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -54,76 +54,76 @@
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Xml" />
     <Reference Include="Xamarin.Android.Support.Annotations">
-      <HintPath>..\packages\Xamarin.Android.Support.Annotations.28.0.0\lib\monoandroid90\Xamarin.Android.Support.Annotations.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Android.Support.Annotations.28.0.0.1\lib\monoandroid90\Xamarin.Android.Support.Annotations.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Android.Arch.Core.Common">
-      <HintPath>..\packages\Xamarin.Android.Arch.Core.Common.1.1.1\lib\monoandroid90\Xamarin.Android.Arch.Core.Common.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Android.Arch.Core.Common.1.1.1.1\lib\monoandroid90\Xamarin.Android.Arch.Core.Common.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Android.Arch.Lifecycle.Common">
-      <HintPath>..\packages\Xamarin.Android.Arch.Lifecycle.Common.1.1.1\lib\monoandroid90\Xamarin.Android.Arch.Lifecycle.Common.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Android.Arch.Lifecycle.Common.1.1.1.1\lib\monoandroid90\Xamarin.Android.Arch.Lifecycle.Common.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Android.Arch.Lifecycle.Runtime">
-      <HintPath>..\packages\Xamarin.Android.Arch.Lifecycle.Runtime.1.1.1\lib\monoandroid90\Xamarin.Android.Arch.Lifecycle.Runtime.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Android.Arch.Lifecycle.Runtime.1.1.1.1\lib\monoandroid90\Xamarin.Android.Arch.Lifecycle.Runtime.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Android.Support.Compat">
-      <HintPath>..\packages\Xamarin.Android.Support.Compat.28.0.0\lib\monoandroid90\Xamarin.Android.Support.Compat.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Android.Support.Compat.28.0.0.1\lib\monoandroid90\Xamarin.Android.Support.Compat.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Android.Support.Core.UI">
-      <HintPath>..\packages\Xamarin.Android.Support.Core.UI.28.0.0\lib\monoandroid90\Xamarin.Android.Support.Core.UI.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Android.Support.Core.UI.28.0.0.1\lib\monoandroid90\Xamarin.Android.Support.Core.UI.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Android.Support.Core.Utils">
-      <HintPath>..\packages\Xamarin.Android.Support.Core.Utils.28.0.0\lib\monoandroid90\Xamarin.Android.Support.Core.Utils.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Android.Support.Core.Utils.28.0.0.1\lib\monoandroid90\Xamarin.Android.Support.Core.Utils.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Android.Support.Fragment">
-      <HintPath>..\packages\Xamarin.Android.Support.Fragment.28.0.0\lib\monoandroid90\Xamarin.Android.Support.Fragment.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Android.Support.Fragment.28.0.0.1\lib\monoandroid90\Xamarin.Android.Support.Fragment.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Android.Support.Media.Compat">
-      <HintPath>..\packages\Xamarin.Android.Support.Media.Compat.28.0.0\lib\monoandroid90\Xamarin.Android.Support.Media.Compat.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Android.Support.Media.Compat.28.0.0.1\lib\monoandroid90\Xamarin.Android.Support.Media.Compat.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Android.Support.Transition">
-      <HintPath>..\packages\Xamarin.Android.Support.Transition.28.0.0\lib\monoandroid90\Xamarin.Android.Support.Transition.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Android.Support.Transition.28.0.0.1\lib\monoandroid90\Xamarin.Android.Support.Transition.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Android.Support.v4">
-      <HintPath>..\packages\Xamarin.Android.Support.v4.28.0.0\lib\monoandroid90\Xamarin.Android.Support.v4.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Android.Support.v4.28.0.0.1\lib\monoandroid90\Xamarin.Android.Support.v4.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Android.Support.v7.CardView">
-      <HintPath>..\packages\Xamarin.Android.Support.v7.CardView.28.0.0\lib\monoandroid90\Xamarin.Android.Support.v7.CardView.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Android.Support.v7.CardView.28.0.0.1\lib\monoandroid90\Xamarin.Android.Support.v7.CardView.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Android.Support.v7.Palette">
-      <HintPath>..\packages\Xamarin.Android.Support.v7.Palette.28.0.0\lib\monoandroid90\Xamarin.Android.Support.v7.Palette.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Android.Support.v7.Palette.28.0.0.1\lib\monoandroid90\Xamarin.Android.Support.v7.Palette.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Android.Support.v7.RecyclerView">
-      <HintPath>..\packages\Xamarin.Android.Support.v7.RecyclerView.28.0.0\lib\monoandroid90\Xamarin.Android.Support.v7.RecyclerView.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Android.Support.v7.RecyclerView.28.0.0.1\lib\monoandroid90\Xamarin.Android.Support.v7.RecyclerView.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Android.Support.Vector.Drawable">
-      <HintPath>..\packages\Xamarin.Android.Support.Vector.Drawable.28.0.0\lib\monoandroid90\Xamarin.Android.Support.Vector.Drawable.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Android.Support.Vector.Drawable.28.0.0.1\lib\monoandroid90\Xamarin.Android.Support.Vector.Drawable.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Android.Support.Animated.Vector.Drawable">
-      <HintPath>..\packages\Xamarin.Android.Support.Animated.Vector.Drawable.28.0.0\lib\monoandroid90\Xamarin.Android.Support.Animated.Vector.Drawable.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Android.Support.Animated.Vector.Drawable.28.0.0.1\lib\monoandroid90\Xamarin.Android.Support.Animated.Vector.Drawable.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Android.Support.v7.AppCompat">
-      <HintPath>..\packages\Xamarin.Android.Support.v7.AppCompat.28.0.0\lib\monoandroid90\Xamarin.Android.Support.v7.AppCompat.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Android.Support.v7.AppCompat.28.0.0.1\lib\monoandroid90\Xamarin.Android.Support.v7.AppCompat.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Android.Support.Design">
-      <HintPath>..\packages\Xamarin.Android.Support.Design.28.0.0\lib\monoandroid90\Xamarin.Android.Support.Design.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Android.Support.Design.28.0.0.1\lib\monoandroid90\Xamarin.Android.Support.Design.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Android.Support.v7.MediaRouter">
-      <HintPath>..\packages\Xamarin.Android.Support.v7.MediaRouter.28.0.0\lib\monoandroid90\Xamarin.Android.Support.v7.MediaRouter.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Android.Support.v7.MediaRouter.28.0.0.1\lib\monoandroid90\Xamarin.Android.Support.v7.MediaRouter.dll</HintPath>
     </Reference>
     <Reference Include="FormsViewGroup">
-      <HintPath>..\packages\Xamarin.Forms.3.4.0.1009999\lib\MonoAndroid10\FormsViewGroup.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.3.4.0.1029999\lib\MonoAndroid10\FormsViewGroup.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Core">
-      <HintPath>..\packages\Xamarin.Forms.3.4.0.1009999\lib\MonoAndroid10\Xamarin.Forms.Core.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.3.4.0.1029999\lib\MonoAndroid10\Xamarin.Forms.Core.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Platform.Android">
-      <HintPath>..\packages\Xamarin.Forms.3.4.0.1009999\lib\MonoAndroid10\Xamarin.Forms.Platform.Android.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.3.4.0.1029999\lib\MonoAndroid10\Xamarin.Forms.Platform.Android.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Platform">
-      <HintPath>..\packages\Xamarin.Forms.3.4.0.1009999\lib\MonoAndroid10\Xamarin.Forms.Platform.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.3.4.0.1029999\lib\MonoAndroid10\Xamarin.Forms.Platform.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Xaml">
-      <HintPath>..\packages\Xamarin.Forms.3.4.0.1009999\lib\MonoAndroid10\Xamarin.Forms.Xaml.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.3.4.0.1029999\lib\MonoAndroid10\Xamarin.Forms.Xaml.dll</HintPath>
     </Reference>
     <Reference Include="Polly">
       <HintPath>..\packages\Polly.6.1.2\lib\netstandard2.0\Polly.dll</HintPath>
@@ -141,40 +141,40 @@
       <HintPath>..\packages\AsyncAwaitBestPractices.MVVM.2.1.0\lib\netstandard\AsyncAwaitBestPractices.MVVM.dll</HintPath>
     </Reference>
     <Reference Include="Syncfusion.Licensing">
-      <HintPath>..\packages\Syncfusion.Licensing.16.4.0.47\lib\MonoAndroid10\Syncfusion.Licensing.dll</HintPath>
+      <HintPath>..\packages\Syncfusion.Licensing.16.4.0.48\lib\MonoAndroid10\Syncfusion.Licensing.dll</HintPath>
     </Reference>
     <Reference Include="Syncfusion.Core.XForms.Android">
-      <HintPath>..\packages\Syncfusion.Xamarin.Core.16.4.0.47\lib\MonoAndroid10\Syncfusion.Core.XForms.Android.dll</HintPath>
+      <HintPath>..\packages\Syncfusion.Xamarin.Core.16.4.0.48\lib\MonoAndroid10\Syncfusion.Core.XForms.Android.dll</HintPath>
     </Reference>
     <Reference Include="Syncfusion.Core.XForms">
-      <HintPath>..\packages\Syncfusion.Xamarin.Core.16.4.0.47\lib\MonoAndroid10\Syncfusion.Core.XForms.dll</HintPath>
+      <HintPath>..\packages\Syncfusion.Xamarin.Core.16.4.0.48\lib\MonoAndroid10\Syncfusion.Core.XForms.dll</HintPath>
     </Reference>
     <Reference Include="Syncfusion.SfChart.XForms.Android">
-      <HintPath>..\packages\Syncfusion.Xamarin.SfChart.16.4.0.47\lib\MonoAndroid10\Syncfusion.SfChart.XForms.Android.dll</HintPath>
+      <HintPath>..\packages\Syncfusion.Xamarin.SfChart.16.4.0.48\lib\MonoAndroid10\Syncfusion.SfChart.XForms.Android.dll</HintPath>
     </Reference>
     <Reference Include="Syncfusion.SfChart.XForms">
-      <HintPath>..\packages\Syncfusion.Xamarin.SfChart.16.4.0.47\lib\MonoAndroid10\Syncfusion.SfChart.XForms.dll</HintPath>
+      <HintPath>..\packages\Syncfusion.Xamarin.SfChart.16.4.0.48\lib\MonoAndroid10\Syncfusion.SfChart.XForms.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.AppCenter.Android.Bindings">
-      <HintPath>..\packages\Microsoft.AppCenter.1.12.0\lib\MonoAndroid403\Microsoft.AppCenter.Android.Bindings.dll</HintPath>
+      <HintPath>..\packages\Microsoft.AppCenter.1.13.0\lib\MonoAndroid403\Microsoft.AppCenter.Android.Bindings.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.AppCenter">
-      <HintPath>..\packages\Microsoft.AppCenter.1.12.0\lib\MonoAndroid403\Microsoft.AppCenter.dll</HintPath>
+      <HintPath>..\packages\Microsoft.AppCenter.1.13.0\lib\MonoAndroid403\Microsoft.AppCenter.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.AppCenter.Analytics.Android.Bindings">
-      <HintPath>..\packages\Microsoft.AppCenter.Analytics.1.12.0\lib\MonoAndroid403\Microsoft.AppCenter.Analytics.Android.Bindings.dll</HintPath>
+      <HintPath>..\packages\Microsoft.AppCenter.Analytics.1.13.0\lib\MonoAndroid403\Microsoft.AppCenter.Analytics.Android.Bindings.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.AppCenter.Analytics">
-      <HintPath>..\packages\Microsoft.AppCenter.Analytics.1.12.0\lib\MonoAndroid403\Microsoft.AppCenter.Analytics.dll</HintPath>
+      <HintPath>..\packages\Microsoft.AppCenter.Analytics.1.13.0\lib\MonoAndroid403\Microsoft.AppCenter.Analytics.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.AppCenter.Crashes.Android.Bindings">
-      <HintPath>..\packages\Microsoft.AppCenter.Crashes.1.12.0\lib\MonoAndroid403\Microsoft.AppCenter.Crashes.Android.Bindings.dll</HintPath>
+      <HintPath>..\packages\Microsoft.AppCenter.Crashes.1.13.0\lib\MonoAndroid403\Microsoft.AppCenter.Crashes.Android.Bindings.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.AppCenter.Crashes">
-      <HintPath>..\packages\Microsoft.AppCenter.Crashes.1.12.0\lib\MonoAndroid403\Microsoft.AppCenter.Crashes.dll</HintPath>
+      <HintPath>..\packages\Microsoft.AppCenter.Crashes.1.13.0\lib\MonoAndroid403\Microsoft.AppCenter.Crashes.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Android.Support.CustomTabs">
-      <HintPath>..\packages\Xamarin.Android.Support.CustomTabs.28.0.0\lib\monoandroid90\Xamarin.Android.Support.CustomTabs.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Android.Support.CustomTabs.28.0.0.1\lib\monoandroid90\Xamarin.Android.Support.CustomTabs.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Essentials">
       <HintPath>..\packages\Xamarin.Essentials.1.0.1\lib\monoandroid81\Xamarin.Essentials.dll</HintPath>
@@ -183,61 +183,61 @@
     <Reference Include="System.Numerics" />
     <Reference Include="System.Numerics.Vectors" />
     <Reference Include="Xamarin.Android.Arch.Core.Runtime">
-      <HintPath>..\packages\Xamarin.Android.Arch.Core.Runtime.1.1.1\lib\monoandroid90\Xamarin.Android.Arch.Core.Runtime.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Android.Arch.Core.Runtime.1.1.1.1\lib\monoandroid90\Xamarin.Android.Arch.Core.Runtime.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Android.Arch.Lifecycle.LiveData.Core">
-      <HintPath>..\packages\Xamarin.Android.Arch.Lifecycle.LiveData.Core.1.1.1\lib\monoandroid90\Xamarin.Android.Arch.Lifecycle.LiveData.Core.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Android.Arch.Lifecycle.LiveData.Core.1.1.1.1\lib\monoandroid90\Xamarin.Android.Arch.Lifecycle.LiveData.Core.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Android.Arch.Lifecycle.LiveData">
-      <HintPath>..\packages\Xamarin.Android.Arch.Lifecycle.LiveData.1.1.1\lib\monoandroid90\Xamarin.Android.Arch.Lifecycle.LiveData.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Android.Arch.Lifecycle.LiveData.1.1.1.1\lib\monoandroid90\Xamarin.Android.Arch.Lifecycle.LiveData.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Android.Arch.Lifecycle.ViewModel">
-      <HintPath>..\packages\Xamarin.Android.Arch.Lifecycle.ViewModel.1.1.1\lib\monoandroid90\Xamarin.Android.Arch.Lifecycle.ViewModel.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Android.Arch.Lifecycle.ViewModel.1.1.1.1\lib\monoandroid90\Xamarin.Android.Arch.Lifecycle.ViewModel.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Android.Support.Collections">
-      <HintPath>..\packages\Xamarin.Android.Support.Collections.28.0.0\lib\monoandroid90\Xamarin.Android.Support.Collections.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Android.Support.Collections.28.0.0.1\lib\monoandroid90\Xamarin.Android.Support.Collections.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Android.Support.CursorAdapter">
-      <HintPath>..\packages\Xamarin.Android.Support.CursorAdapter.28.0.0\lib\monoandroid90\Xamarin.Android.Support.CursorAdapter.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Android.Support.CursorAdapter.28.0.0.1\lib\monoandroid90\Xamarin.Android.Support.CursorAdapter.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Android.Support.DocumentFile">
-      <HintPath>..\packages\Xamarin.Android.Support.DocumentFile.28.0.0\lib\monoandroid90\Xamarin.Android.Support.DocumentFile.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Android.Support.DocumentFile.28.0.0.1\lib\monoandroid90\Xamarin.Android.Support.DocumentFile.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Android.Support.Interpolator">
-      <HintPath>..\packages\Xamarin.Android.Support.Interpolator.28.0.0\lib\monoandroid90\Xamarin.Android.Support.Interpolator.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Android.Support.Interpolator.28.0.0.1\lib\monoandroid90\Xamarin.Android.Support.Interpolator.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Android.Support.LocalBroadcastManager">
-      <HintPath>..\packages\Xamarin.Android.Support.LocalBroadcastManager.28.0.0\lib\monoandroid90\Xamarin.Android.Support.LocalBroadcastManager.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Android.Support.LocalBroadcastManager.28.0.0.1\lib\monoandroid90\Xamarin.Android.Support.LocalBroadcastManager.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Android.Support.Print">
-      <HintPath>..\packages\Xamarin.Android.Support.Print.28.0.0\lib\monoandroid90\Xamarin.Android.Support.Print.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Android.Support.Print.28.0.0.1\lib\monoandroid90\Xamarin.Android.Support.Print.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Android.Support.VersionedParcelable">
-      <HintPath>..\packages\Xamarin.Android.Support.VersionedParcelable.28.0.0\lib\monoandroid90\Xamarin.Android.Support.VersionedParcelable.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Android.Support.VersionedParcelable.28.0.0.1\lib\monoandroid90\Xamarin.Android.Support.VersionedParcelable.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Android.Support.AsyncLayoutInflater">
-      <HintPath>..\packages\Xamarin.Android.Support.AsyncLayoutInflater.28.0.0\lib\monoandroid90\Xamarin.Android.Support.AsyncLayoutInflater.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Android.Support.AsyncLayoutInflater.28.0.0.1\lib\monoandroid90\Xamarin.Android.Support.AsyncLayoutInflater.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Android.Support.CustomView">
-      <HintPath>..\packages\Xamarin.Android.Support.CustomView.28.0.0\lib\monoandroid90\Xamarin.Android.Support.CustomView.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Android.Support.CustomView.28.0.0.1\lib\monoandroid90\Xamarin.Android.Support.CustomView.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Android.Support.CoordinaterLayout">
-      <HintPath>..\packages\Xamarin.Android.Support.CoordinaterLayout.28.0.0\lib\monoandroid90\Xamarin.Android.Support.CoordinaterLayout.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Android.Support.CoordinaterLayout.28.0.0.1\lib\monoandroid90\Xamarin.Android.Support.CoordinaterLayout.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Android.Support.DrawerLayout">
-      <HintPath>..\packages\Xamarin.Android.Support.DrawerLayout.28.0.0\lib\monoandroid90\Xamarin.Android.Support.DrawerLayout.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Android.Support.DrawerLayout.28.0.0.1\lib\monoandroid90\Xamarin.Android.Support.DrawerLayout.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Android.Support.Loader">
-      <HintPath>..\packages\Xamarin.Android.Support.Loader.28.0.0\lib\monoandroid90\Xamarin.Android.Support.Loader.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Android.Support.Loader.28.0.0.1\lib\monoandroid90\Xamarin.Android.Support.Loader.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Android.Support.SlidingPaneLayout">
-      <HintPath>..\packages\Xamarin.Android.Support.SlidingPaneLayout.28.0.0\lib\monoandroid90\Xamarin.Android.Support.SlidingPaneLayout.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Android.Support.SlidingPaneLayout.28.0.0.1\lib\monoandroid90\Xamarin.Android.Support.SlidingPaneLayout.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Android.Support.SwipeRefreshLayout">
-      <HintPath>..\packages\Xamarin.Android.Support.SwipeRefreshLayout.28.0.0\lib\monoandroid90\Xamarin.Android.Support.SwipeRefreshLayout.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Android.Support.SwipeRefreshLayout.28.0.0.1\lib\monoandroid90\Xamarin.Android.Support.SwipeRefreshLayout.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Android.Support.ViewPager">
-      <HintPath>..\packages\Xamarin.Android.Support.ViewPager.28.0.0\lib\monoandroid90\Xamarin.Android.Support.ViewPager.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Android.Support.ViewPager.28.0.0.1\lib\monoandroid90\Xamarin.Android.Support.ViewPager.dll</HintPath>
     </Reference>
     <Reference Include="Plugin.CurrentActivity">
       <HintPath>..\packages\Plugin.CurrentActivity.2.1.0.4\lib\monoandroid44\Plugin.CurrentActivity.dll</HintPath>
@@ -289,45 +289,45 @@
     </ProjectReference>
   </ItemGroup>
  <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
- <Import Project="..\packages\Xamarin.Forms.3.4.0.1009999\build\Xamarin.Forms.targets" Condition="Exists('..\packages\Xamarin.Forms.3.4.0.1009999\build\Xamarin.Forms.targets')" />
  <Import Project="..\packages\Refit.4.6.58\build\netstandard1.4\refit.targets" Condition="Exists('..\packages\Refit.4.6.58\build\netstandard1.4\refit.targets')" />
- <Import Project="..\packages\Xamarin.Android.Support.Annotations.28.0.0\build\monoandroid90\Xamarin.Android.Support.Annotations.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Annotations.28.0.0\build\monoandroid90\Xamarin.Android.Support.Annotations.targets')" />
- <Import Project="..\packages\Xamarin.Android.Arch.Core.Common.1.1.1\build\monoandroid90\Xamarin.Android.Arch.Core.Common.targets" Condition="Exists('..\packages\Xamarin.Android.Arch.Core.Common.1.1.1\build\monoandroid90\Xamarin.Android.Arch.Core.Common.targets')" />
- <Import Project="..\packages\Xamarin.Android.Arch.Core.Runtime.1.1.1\build\monoandroid90\Xamarin.Android.Arch.Core.Runtime.targets" Condition="Exists('..\packages\Xamarin.Android.Arch.Core.Runtime.1.1.1\build\monoandroid90\Xamarin.Android.Arch.Core.Runtime.targets')" />
- <Import Project="..\packages\Xamarin.Android.Arch.Lifecycle.Common.1.1.1\build\monoandroid90\Xamarin.Android.Arch.Lifecycle.Common.targets" Condition="Exists('..\packages\Xamarin.Android.Arch.Lifecycle.Common.1.1.1\build\monoandroid90\Xamarin.Android.Arch.Lifecycle.Common.targets')" />
- <Import Project="..\packages\Xamarin.Android.Arch.Lifecycle.LiveData.Core.1.1.1\build\monoandroid90\Xamarin.Android.Arch.Lifecycle.LiveData.Core.targets" Condition="Exists('..\packages\Xamarin.Android.Arch.Lifecycle.LiveData.Core.1.1.1\build\monoandroid90\Xamarin.Android.Arch.Lifecycle.LiveData.Core.targets')" />
- <Import Project="..\packages\Xamarin.Android.Arch.Lifecycle.LiveData.1.1.1\build\monoandroid90\Xamarin.Android.Arch.Lifecycle.LiveData.targets" Condition="Exists('..\packages\Xamarin.Android.Arch.Lifecycle.LiveData.1.1.1\build\monoandroid90\Xamarin.Android.Arch.Lifecycle.LiveData.targets')" />
- <Import Project="..\packages\Xamarin.Android.Arch.Lifecycle.Runtime.1.1.1\build\monoandroid90\Xamarin.Android.Arch.Lifecycle.Runtime.targets" Condition="Exists('..\packages\Xamarin.Android.Arch.Lifecycle.Runtime.1.1.1\build\monoandroid90\Xamarin.Android.Arch.Lifecycle.Runtime.targets')" />
- <Import Project="..\packages\Xamarin.Android.Arch.Lifecycle.ViewModel.1.1.1\build\monoandroid90\Xamarin.Android.Arch.Lifecycle.ViewModel.targets" Condition="Exists('..\packages\Xamarin.Android.Arch.Lifecycle.ViewModel.1.1.1\build\monoandroid90\Xamarin.Android.Arch.Lifecycle.ViewModel.targets')" />
- <Import Project="..\packages\Xamarin.Android.Support.Collections.28.0.0\build\monoandroid90\Xamarin.Android.Support.Collections.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Collections.28.0.0\build\monoandroid90\Xamarin.Android.Support.Collections.targets')" />
- <Import Project="..\packages\Xamarin.Android.Support.CursorAdapter.28.0.0\build\monoandroid90\Xamarin.Android.Support.CursorAdapter.targets" Condition="Exists('..\packages\Xamarin.Android.Support.CursorAdapter.28.0.0\build\monoandroid90\Xamarin.Android.Support.CursorAdapter.targets')" />
- <Import Project="..\packages\Xamarin.Android.Support.DocumentFile.28.0.0\build\monoandroid90\Xamarin.Android.Support.DocumentFile.targets" Condition="Exists('..\packages\Xamarin.Android.Support.DocumentFile.28.0.0\build\monoandroid90\Xamarin.Android.Support.DocumentFile.targets')" />
- <Import Project="..\packages\Xamarin.Android.Support.Interpolator.28.0.0\build\monoandroid90\Xamarin.Android.Support.Interpolator.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Interpolator.28.0.0\build\monoandroid90\Xamarin.Android.Support.Interpolator.targets')" />
- <Import Project="..\packages\Xamarin.Android.Support.LocalBroadcastManager.28.0.0\build\monoandroid90\Xamarin.Android.Support.LocalBroadcastManager.targets" Condition="Exists('..\packages\Xamarin.Android.Support.LocalBroadcastManager.28.0.0\build\monoandroid90\Xamarin.Android.Support.LocalBroadcastManager.targets')" />
- <Import Project="..\packages\Xamarin.Android.Support.Print.28.0.0\build\monoandroid90\Xamarin.Android.Support.Print.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Print.28.0.0\build\monoandroid90\Xamarin.Android.Support.Print.targets')" />
- <Import Project="..\packages\Xamarin.Android.Support.v7.CardView.28.0.0\build\monoandroid90\Xamarin.Android.Support.v7.CardView.targets" Condition="Exists('..\packages\Xamarin.Android.Support.v7.CardView.28.0.0\build\monoandroid90\Xamarin.Android.Support.v7.CardView.targets')" />
- <Import Project="..\packages\Xamarin.Android.Support.VersionedParcelable.28.0.0\build\monoandroid90\Xamarin.Android.Support.VersionedParcelable.targets" Condition="Exists('..\packages\Xamarin.Android.Support.VersionedParcelable.28.0.0\build\monoandroid90\Xamarin.Android.Support.VersionedParcelable.targets')" />
- <Import Project="..\packages\Xamarin.Android.Support.Compat.28.0.0\build\monoandroid90\Xamarin.Android.Support.Compat.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Compat.28.0.0\build\monoandroid90\Xamarin.Android.Support.Compat.targets')" />
- <Import Project="..\packages\Xamarin.Android.Support.AsyncLayoutInflater.28.0.0\build\monoandroid90\Xamarin.Android.Support.AsyncLayoutInflater.targets" Condition="Exists('..\packages\Xamarin.Android.Support.AsyncLayoutInflater.28.0.0\build\monoandroid90\Xamarin.Android.Support.AsyncLayoutInflater.targets')" />
- <Import Project="..\packages\Xamarin.Android.Support.CustomView.28.0.0\build\monoandroid90\Xamarin.Android.Support.CustomView.targets" Condition="Exists('..\packages\Xamarin.Android.Support.CustomView.28.0.0\build\monoandroid90\Xamarin.Android.Support.CustomView.targets')" />
- <Import Project="..\packages\Xamarin.Android.Support.CoordinaterLayout.28.0.0\build\monoandroid90\Xamarin.Android.Support.CoordinaterLayout.targets" Condition="Exists('..\packages\Xamarin.Android.Support.CoordinaterLayout.28.0.0\build\monoandroid90\Xamarin.Android.Support.CoordinaterLayout.targets')" />
- <Import Project="..\packages\Xamarin.Android.Support.DrawerLayout.28.0.0\build\monoandroid90\Xamarin.Android.Support.DrawerLayout.targets" Condition="Exists('..\packages\Xamarin.Android.Support.DrawerLayout.28.0.0\build\monoandroid90\Xamarin.Android.Support.DrawerLayout.targets')" />
- <Import Project="..\packages\Xamarin.Android.Support.Loader.28.0.0\build\monoandroid90\Xamarin.Android.Support.Loader.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Loader.28.0.0\build\monoandroid90\Xamarin.Android.Support.Loader.targets')" />
- <Import Project="..\packages\Xamarin.Android.Support.Core.Utils.28.0.0\build\monoandroid90\Xamarin.Android.Support.Core.Utils.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Core.Utils.28.0.0\build\monoandroid90\Xamarin.Android.Support.Core.Utils.targets')" />
- <Import Project="..\packages\Xamarin.Android.Support.Media.Compat.28.0.0\build\monoandroid90\Xamarin.Android.Support.Media.Compat.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Media.Compat.28.0.0\build\monoandroid90\Xamarin.Android.Support.Media.Compat.targets')" />
- <Import Project="..\packages\Xamarin.Android.Support.SlidingPaneLayout.28.0.0\build\monoandroid90\Xamarin.Android.Support.SlidingPaneLayout.targets" Condition="Exists('..\packages\Xamarin.Android.Support.SlidingPaneLayout.28.0.0\build\monoandroid90\Xamarin.Android.Support.SlidingPaneLayout.targets')" />
- <Import Project="..\packages\Xamarin.Android.Support.SwipeRefreshLayout.28.0.0\build\monoandroid90\Xamarin.Android.Support.SwipeRefreshLayout.targets" Condition="Exists('..\packages\Xamarin.Android.Support.SwipeRefreshLayout.28.0.0\build\monoandroid90\Xamarin.Android.Support.SwipeRefreshLayout.targets')" />
- <Import Project="..\packages\Xamarin.Android.Support.v7.Palette.28.0.0\build\monoandroid90\Xamarin.Android.Support.v7.Palette.targets" Condition="Exists('..\packages\Xamarin.Android.Support.v7.Palette.28.0.0\build\monoandroid90\Xamarin.Android.Support.v7.Palette.targets')" />
- <Import Project="..\packages\Xamarin.Android.Support.Vector.Drawable.28.0.0\build\monoandroid90\Xamarin.Android.Support.Vector.Drawable.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Vector.Drawable.28.0.0\build\monoandroid90\Xamarin.Android.Support.Vector.Drawable.targets')" />
- <Import Project="..\packages\Xamarin.Android.Support.ViewPager.28.0.0\build\monoandroid90\Xamarin.Android.Support.ViewPager.targets" Condition="Exists('..\packages\Xamarin.Android.Support.ViewPager.28.0.0\build\monoandroid90\Xamarin.Android.Support.ViewPager.targets')" />
- <Import Project="..\packages\Xamarin.Android.Support.Core.UI.28.0.0\build\monoandroid90\Xamarin.Android.Support.Core.UI.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Core.UI.28.0.0\build\monoandroid90\Xamarin.Android.Support.Core.UI.targets')" />
- <Import Project="..\packages\Xamarin.Android.Support.Animated.Vector.Drawable.28.0.0\build\monoandroid90\Xamarin.Android.Support.Animated.Vector.Drawable.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Animated.Vector.Drawable.28.0.0\build\monoandroid90\Xamarin.Android.Support.Animated.Vector.Drawable.targets')" />
- <Import Project="..\packages\Xamarin.Android.Support.CustomTabs.28.0.0\build\monoandroid90\Xamarin.Android.Support.CustomTabs.targets" Condition="Exists('..\packages\Xamarin.Android.Support.CustomTabs.28.0.0\build\monoandroid90\Xamarin.Android.Support.CustomTabs.targets')" />
- <Import Project="..\packages\Xamarin.Android.Support.Fragment.28.0.0\build\monoandroid90\Xamarin.Android.Support.Fragment.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Fragment.28.0.0\build\monoandroid90\Xamarin.Android.Support.Fragment.targets')" />
- <Import Project="..\packages\Xamarin.Android.Support.Transition.28.0.0\build\monoandroid90\Xamarin.Android.Support.Transition.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Transition.28.0.0\build\monoandroid90\Xamarin.Android.Support.Transition.targets')" />
- <Import Project="..\packages\Xamarin.Android.Support.v4.28.0.0\build\monoandroid90\Xamarin.Android.Support.v4.targets" Condition="Exists('..\packages\Xamarin.Android.Support.v4.28.0.0\build\monoandroid90\Xamarin.Android.Support.v4.targets')" />
- <Import Project="..\packages\Xamarin.Android.Support.v7.AppCompat.28.0.0\build\monoandroid90\Xamarin.Android.Support.v7.AppCompat.targets" Condition="Exists('..\packages\Xamarin.Android.Support.v7.AppCompat.28.0.0\build\monoandroid90\Xamarin.Android.Support.v7.AppCompat.targets')" />
- <Import Project="..\packages\Xamarin.Android.Support.v7.RecyclerView.28.0.0\build\monoandroid90\Xamarin.Android.Support.v7.RecyclerView.targets" Condition="Exists('..\packages\Xamarin.Android.Support.v7.RecyclerView.28.0.0\build\monoandroid90\Xamarin.Android.Support.v7.RecyclerView.targets')" />
- <Import Project="..\packages\Xamarin.Android.Support.Design.28.0.0\build\monoandroid90\Xamarin.Android.Support.Design.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Design.28.0.0\build\monoandroid90\Xamarin.Android.Support.Design.targets')" />
- <Import Project="..\packages\Xamarin.Android.Support.v7.MediaRouter.28.0.0\build\monoandroid90\Xamarin.Android.Support.v7.MediaRouter.targets" Condition="Exists('..\packages\Xamarin.Android.Support.v7.MediaRouter.28.0.0\build\monoandroid90\Xamarin.Android.Support.v7.MediaRouter.targets')" />
+ <Import Project="..\packages\Xamarin.Android.Support.Annotations.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.Annotations.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Annotations.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.Annotations.targets')" />
+ <Import Project="..\packages\Xamarin.Android.Arch.Core.Common.1.1.1.1\build\monoandroid90\Xamarin.Android.Arch.Core.Common.targets" Condition="Exists('..\packages\Xamarin.Android.Arch.Core.Common.1.1.1.1\build\monoandroid90\Xamarin.Android.Arch.Core.Common.targets')" />
+ <Import Project="..\packages\Xamarin.Android.Arch.Core.Runtime.1.1.1.1\build\monoandroid90\Xamarin.Android.Arch.Core.Runtime.targets" Condition="Exists('..\packages\Xamarin.Android.Arch.Core.Runtime.1.1.1.1\build\monoandroid90\Xamarin.Android.Arch.Core.Runtime.targets')" />
+ <Import Project="..\packages\Xamarin.Android.Arch.Lifecycle.Common.1.1.1.1\build\monoandroid90\Xamarin.Android.Arch.Lifecycle.Common.targets" Condition="Exists('..\packages\Xamarin.Android.Arch.Lifecycle.Common.1.1.1.1\build\monoandroid90\Xamarin.Android.Arch.Lifecycle.Common.targets')" />
+ <Import Project="..\packages\Xamarin.Android.Arch.Lifecycle.LiveData.Core.1.1.1.1\build\monoandroid90\Xamarin.Android.Arch.Lifecycle.LiveData.Core.targets" Condition="Exists('..\packages\Xamarin.Android.Arch.Lifecycle.LiveData.Core.1.1.1.1\build\monoandroid90\Xamarin.Android.Arch.Lifecycle.LiveData.Core.targets')" />
+ <Import Project="..\packages\Xamarin.Android.Arch.Lifecycle.LiveData.1.1.1.1\build\monoandroid90\Xamarin.Android.Arch.Lifecycle.LiveData.targets" Condition="Exists('..\packages\Xamarin.Android.Arch.Lifecycle.LiveData.1.1.1.1\build\monoandroid90\Xamarin.Android.Arch.Lifecycle.LiveData.targets')" />
+ <Import Project="..\packages\Xamarin.Android.Arch.Lifecycle.Runtime.1.1.1.1\build\monoandroid90\Xamarin.Android.Arch.Lifecycle.Runtime.targets" Condition="Exists('..\packages\Xamarin.Android.Arch.Lifecycle.Runtime.1.1.1.1\build\monoandroid90\Xamarin.Android.Arch.Lifecycle.Runtime.targets')" />
+ <Import Project="..\packages\Xamarin.Android.Arch.Lifecycle.ViewModel.1.1.1.1\build\monoandroid90\Xamarin.Android.Arch.Lifecycle.ViewModel.targets" Condition="Exists('..\packages\Xamarin.Android.Arch.Lifecycle.ViewModel.1.1.1.1\build\monoandroid90\Xamarin.Android.Arch.Lifecycle.ViewModel.targets')" />
+ <Import Project="..\packages\Xamarin.Android.Support.Collections.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.Collections.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Collections.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.Collections.targets')" />
+ <Import Project="..\packages\Xamarin.Android.Support.CursorAdapter.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.CursorAdapter.targets" Condition="Exists('..\packages\Xamarin.Android.Support.CursorAdapter.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.CursorAdapter.targets')" />
+ <Import Project="..\packages\Xamarin.Android.Support.DocumentFile.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.DocumentFile.targets" Condition="Exists('..\packages\Xamarin.Android.Support.DocumentFile.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.DocumentFile.targets')" />
+ <Import Project="..\packages\Xamarin.Android.Support.Interpolator.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.Interpolator.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Interpolator.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.Interpolator.targets')" />
+ <Import Project="..\packages\Xamarin.Android.Support.LocalBroadcastManager.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.LocalBroadcastManager.targets" Condition="Exists('..\packages\Xamarin.Android.Support.LocalBroadcastManager.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.LocalBroadcastManager.targets')" />
+ <Import Project="..\packages\Xamarin.Android.Support.Print.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.Print.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Print.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.Print.targets')" />
+ <Import Project="..\packages\Xamarin.Android.Support.v7.CardView.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.v7.CardView.targets" Condition="Exists('..\packages\Xamarin.Android.Support.v7.CardView.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.v7.CardView.targets')" />
+ <Import Project="..\packages\Xamarin.Android.Support.VersionedParcelable.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.VersionedParcelable.targets" Condition="Exists('..\packages\Xamarin.Android.Support.VersionedParcelable.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.VersionedParcelable.targets')" />
+ <Import Project="..\packages\Xamarin.Android.Support.Compat.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.Compat.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Compat.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.Compat.targets')" />
+ <Import Project="..\packages\Xamarin.Android.Support.AsyncLayoutInflater.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.AsyncLayoutInflater.targets" Condition="Exists('..\packages\Xamarin.Android.Support.AsyncLayoutInflater.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.AsyncLayoutInflater.targets')" />
+ <Import Project="..\packages\Xamarin.Android.Support.CustomView.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.CustomView.targets" Condition="Exists('..\packages\Xamarin.Android.Support.CustomView.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.CustomView.targets')" />
+ <Import Project="..\packages\Xamarin.Android.Support.CoordinaterLayout.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.CoordinaterLayout.targets" Condition="Exists('..\packages\Xamarin.Android.Support.CoordinaterLayout.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.CoordinaterLayout.targets')" />
+ <Import Project="..\packages\Xamarin.Android.Support.DrawerLayout.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.DrawerLayout.targets" Condition="Exists('..\packages\Xamarin.Android.Support.DrawerLayout.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.DrawerLayout.targets')" />
+ <Import Project="..\packages\Xamarin.Android.Support.Loader.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.Loader.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Loader.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.Loader.targets')" />
+ <Import Project="..\packages\Xamarin.Android.Support.Core.Utils.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.Core.Utils.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Core.Utils.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.Core.Utils.targets')" />
+ <Import Project="..\packages\Xamarin.Android.Support.Media.Compat.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.Media.Compat.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Media.Compat.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.Media.Compat.targets')" />
+ <Import Project="..\packages\Xamarin.Android.Support.SlidingPaneLayout.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.SlidingPaneLayout.targets" Condition="Exists('..\packages\Xamarin.Android.Support.SlidingPaneLayout.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.SlidingPaneLayout.targets')" />
+ <Import Project="..\packages\Xamarin.Android.Support.SwipeRefreshLayout.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.SwipeRefreshLayout.targets" Condition="Exists('..\packages\Xamarin.Android.Support.SwipeRefreshLayout.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.SwipeRefreshLayout.targets')" />
+ <Import Project="..\packages\Xamarin.Android.Support.v7.Palette.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.v7.Palette.targets" Condition="Exists('..\packages\Xamarin.Android.Support.v7.Palette.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.v7.Palette.targets')" />
+ <Import Project="..\packages\Xamarin.Android.Support.Vector.Drawable.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.Vector.Drawable.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Vector.Drawable.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.Vector.Drawable.targets')" />
+ <Import Project="..\packages\Xamarin.Android.Support.ViewPager.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.ViewPager.targets" Condition="Exists('..\packages\Xamarin.Android.Support.ViewPager.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.ViewPager.targets')" />
+ <Import Project="..\packages\Xamarin.Android.Support.Core.UI.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.Core.UI.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Core.UI.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.Core.UI.targets')" />
+ <Import Project="..\packages\Xamarin.Android.Support.Animated.Vector.Drawable.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.Animated.Vector.Drawable.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Animated.Vector.Drawable.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.Animated.Vector.Drawable.targets')" />
+ <Import Project="..\packages\Xamarin.Android.Support.CustomTabs.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.CustomTabs.targets" Condition="Exists('..\packages\Xamarin.Android.Support.CustomTabs.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.CustomTabs.targets')" />
+ <Import Project="..\packages\Xamarin.Android.Support.Fragment.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.Fragment.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Fragment.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.Fragment.targets')" />
+ <Import Project="..\packages\Xamarin.Android.Support.Transition.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.Transition.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Transition.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.Transition.targets')" />
+ <Import Project="..\packages\Xamarin.Android.Support.v4.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.v4.targets" Condition="Exists('..\packages\Xamarin.Android.Support.v4.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.v4.targets')" />
+ <Import Project="..\packages\Xamarin.Android.Support.v7.AppCompat.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.v7.AppCompat.targets" Condition="Exists('..\packages\Xamarin.Android.Support.v7.AppCompat.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.v7.AppCompat.targets')" />
+ <Import Project="..\packages\Xamarin.Android.Support.v7.RecyclerView.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.v7.RecyclerView.targets" Condition="Exists('..\packages\Xamarin.Android.Support.v7.RecyclerView.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.v7.RecyclerView.targets')" />
+ <Import Project="..\packages\Xamarin.Android.Support.Design.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.Design.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Design.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.Design.targets')" />
+ <Import Project="..\packages\Xamarin.Android.Support.v7.MediaRouter.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.v7.MediaRouter.targets" Condition="Exists('..\packages\Xamarin.Android.Support.v7.MediaRouter.28.0.0.1\build\monoandroid90\Xamarin.Android.Support.v7.MediaRouter.targets')" />
+ <Import Project="..\packages\Xamarin.Forms.3.4.0.1029999\build\Xamarin.Forms.targets" Condition="Exists('..\packages\Xamarin.Forms.3.4.0.1029999\build\Xamarin.Forms.targets')" />
 </Project>

--- a/mobile/VotingApp/VotingApp.Android/packages.config
+++ b/mobile/VotingApp/VotingApp.Android/packages.config
@@ -2,56 +2,56 @@
 <packages>
   <package id="AsyncAwaitBestPractices" version="2.1.0" targetFramework="monoandroid90" />
   <package id="AsyncAwaitBestPractices.MVVM" version="2.1.0" targetFramework="monoandroid90" />
-  <package id="Microsoft.AppCenter" version="1.12.0" targetFramework="monoandroid90" />
-  <package id="Microsoft.AppCenter.Analytics" version="1.12.0" targetFramework="monoandroid90" />
-  <package id="Microsoft.AppCenter.Crashes" version="1.12.0" targetFramework="monoandroid90" />
+  <package id="Microsoft.AppCenter" version="1.13.0" targetFramework="monoandroid90" />
+  <package id="Microsoft.AppCenter.Analytics" version="1.13.0" targetFramework="monoandroid90" />
+  <package id="Microsoft.AppCenter.Crashes" version="1.13.0" targetFramework="monoandroid90" />
   <package id="Newtonsoft.Json" version="12.0.1" targetFramework="monoandroid90" />
   <package id="Plugin.CurrentActivity" version="2.1.0.4" targetFramework="monoandroid90" />
   <package id="Polly" version="6.1.2" targetFramework="monoandroid90" />
   <package id="Refit" version="4.6.58" targetFramework="monoandroid90" />
-  <package id="Syncfusion.Licensing" version="16.4.0.47" targetFramework="monoandroid90" />
-  <package id="Syncfusion.Xamarin.Core" version="16.4.0.47" targetFramework="monoandroid90" />
-  <package id="Syncfusion.Xamarin.SfChart" version="16.4.0.47" targetFramework="monoandroid90" />
+  <package id="Syncfusion.Licensing" version="16.4.0.48" targetFramework="monoandroid90" />
+  <package id="Syncfusion.Xamarin.Core" version="16.4.0.48" targetFramework="monoandroid90" />
+  <package id="Syncfusion.Xamarin.SfChart" version="16.4.0.48" targetFramework="monoandroid90" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="monoandroid90" />
-  <package id="Xamarin.Android.Arch.Core.Common" version="1.1.1" targetFramework="monoandroid90" />
-  <package id="Xamarin.Android.Arch.Core.Runtime" version="1.1.1" targetFramework="monoandroid90" />
-  <package id="Xamarin.Android.Arch.Lifecycle.Common" version="1.1.1" targetFramework="monoandroid90" />
-  <package id="Xamarin.Android.Arch.Lifecycle.LiveData" version="1.1.1" targetFramework="monoandroid90" />
-  <package id="Xamarin.Android.Arch.Lifecycle.LiveData.Core" version="1.1.1" targetFramework="monoandroid90" />
-  <package id="Xamarin.Android.Arch.Lifecycle.Runtime" version="1.1.1" targetFramework="monoandroid90" />
-  <package id="Xamarin.Android.Arch.Lifecycle.ViewModel" version="1.1.1" targetFramework="monoandroid90" />
-  <package id="Xamarin.Android.Support.Animated.Vector.Drawable" version="28.0.0" targetFramework="monoandroid90" />
-  <package id="Xamarin.Android.Support.Annotations" version="28.0.0" targetFramework="monoandroid90" />
-  <package id="Xamarin.Android.Support.AsyncLayoutInflater" version="28.0.0" targetFramework="monoandroid90" />
-  <package id="Xamarin.Android.Support.Collections" version="28.0.0" targetFramework="monoandroid90" />
-  <package id="Xamarin.Android.Support.Compat" version="28.0.0" targetFramework="monoandroid90" />
-  <package id="Xamarin.Android.Support.CoordinaterLayout" version="28.0.0" targetFramework="monoandroid90" />
-  <package id="Xamarin.Android.Support.Core.UI" version="28.0.0" targetFramework="monoandroid90" />
-  <package id="Xamarin.Android.Support.Core.Utils" version="28.0.0" targetFramework="monoandroid90" />
-  <package id="Xamarin.Android.Support.CursorAdapter" version="28.0.0" targetFramework="monoandroid90" />
-  <package id="Xamarin.Android.Support.CustomTabs" version="28.0.0" targetFramework="monoandroid90" />
-  <package id="Xamarin.Android.Support.CustomView" version="28.0.0" targetFramework="monoandroid90" />
-  <package id="Xamarin.Android.Support.Design" version="28.0.0" targetFramework="monoandroid90" />
-  <package id="Xamarin.Android.Support.DocumentFile" version="28.0.0" targetFramework="monoandroid90" />
-  <package id="Xamarin.Android.Support.DrawerLayout" version="28.0.0" targetFramework="monoandroid90" />
-  <package id="Xamarin.Android.Support.Fragment" version="28.0.0" targetFramework="monoandroid90" />
-  <package id="Xamarin.Android.Support.Interpolator" version="28.0.0" targetFramework="monoandroid90" />
-  <package id="Xamarin.Android.Support.Loader" version="28.0.0" targetFramework="monoandroid90" />
-  <package id="Xamarin.Android.Support.LocalBroadcastManager" version="28.0.0" targetFramework="monoandroid90" />
-  <package id="Xamarin.Android.Support.Media.Compat" version="28.0.0" targetFramework="monoandroid90" />
-  <package id="Xamarin.Android.Support.Print" version="28.0.0" targetFramework="monoandroid90" />
-  <package id="Xamarin.Android.Support.SlidingPaneLayout" version="28.0.0" targetFramework="monoandroid90" />
-  <package id="Xamarin.Android.Support.SwipeRefreshLayout" version="28.0.0" targetFramework="monoandroid90" />
-  <package id="Xamarin.Android.Support.Transition" version="28.0.0" targetFramework="monoandroid90" />
-  <package id="Xamarin.Android.Support.v4" version="28.0.0" targetFramework="monoandroid90" />
-  <package id="Xamarin.Android.Support.v7.AppCompat" version="28.0.0" targetFramework="monoandroid90" />
-  <package id="Xamarin.Android.Support.v7.CardView" version="28.0.0" targetFramework="monoandroid90" />
-  <package id="Xamarin.Android.Support.v7.MediaRouter" version="28.0.0" targetFramework="monoandroid90" />
-  <package id="Xamarin.Android.Support.v7.Palette" version="28.0.0" targetFramework="monoandroid90" />
-  <package id="Xamarin.Android.Support.v7.RecyclerView" version="28.0.0" targetFramework="monoandroid90" />
-  <package id="Xamarin.Android.Support.Vector.Drawable" version="28.0.0" targetFramework="monoandroid90" />
-  <package id="Xamarin.Android.Support.VersionedParcelable" version="28.0.0" targetFramework="monoandroid90" />
-  <package id="Xamarin.Android.Support.ViewPager" version="28.0.0" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Arch.Core.Common" version="1.1.1.1" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Arch.Core.Runtime" version="1.1.1.1" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Arch.Lifecycle.Common" version="1.1.1.1" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Arch.Lifecycle.LiveData" version="1.1.1.1" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Arch.Lifecycle.LiveData.Core" version="1.1.1.1" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Arch.Lifecycle.Runtime" version="1.1.1.1" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Arch.Lifecycle.ViewModel" version="1.1.1.1" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Support.Animated.Vector.Drawable" version="28.0.0.1" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Support.Annotations" version="28.0.0.1" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Support.AsyncLayoutInflater" version="28.0.0.1" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Support.Collections" version="28.0.0.1" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Support.Compat" version="28.0.0.1" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Support.CoordinaterLayout" version="28.0.0.1" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Support.Core.UI" version="28.0.0.1" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Support.Core.Utils" version="28.0.0.1" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Support.CursorAdapter" version="28.0.0.1" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Support.CustomTabs" version="28.0.0.1" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Support.CustomView" version="28.0.0.1" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Support.Design" version="28.0.0.1" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Support.DocumentFile" version="28.0.0.1" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Support.DrawerLayout" version="28.0.0.1" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Support.Fragment" version="28.0.0.1" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Support.Interpolator" version="28.0.0.1" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Support.Loader" version="28.0.0.1" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Support.LocalBroadcastManager" version="28.0.0.1" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Support.Media.Compat" version="28.0.0.1" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Support.Print" version="28.0.0.1" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Support.SlidingPaneLayout" version="28.0.0.1" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Support.SwipeRefreshLayout" version="28.0.0.1" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Support.Transition" version="28.0.0.1" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Support.v4" version="28.0.0.1" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Support.v7.AppCompat" version="28.0.0.1" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Support.v7.CardView" version="28.0.0.1" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Support.v7.MediaRouter" version="28.0.0.1" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Support.v7.Palette" version="28.0.0.1" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Support.v7.RecyclerView" version="28.0.0.1" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Support.Vector.Drawable" version="28.0.0.1" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Support.VersionedParcelable" version="28.0.0.1" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Support.ViewPager" version="28.0.0.1" targetFramework="monoandroid90" />
   <package id="Xamarin.Essentials" version="1.0.1" targetFramework="monoandroid90" />
-  <package id="Xamarin.Forms" version="3.4.0.1009999" targetFramework="monoandroid90" />
+  <package id="Xamarin.Forms" version="3.4.0.1029999" targetFramework="monoandroid90" />
 </packages>

--- a/mobile/VotingApp/VotingApp.iOS/Info.plist
+++ b/mobile/VotingApp/VotingApp.iOS/Info.plist
@@ -21,7 +21,7 @@
 	<key>MinimumOSVersion</key>
 	<string>9.0</string>
 	<key>CFBundleDisplayName</key>
-	<string>VotingApp</string>
+	<string>Voting&#x2007;App</string>
 	<key>CFBundleIdentifier</key>
 	<string>com.minnick.VotingApp</string>
 	<key>CFBundleVersion</key>

--- a/mobile/VotingApp/VotingApp.iOS/VotingApp.iOS.csproj
+++ b/mobile/VotingApp/VotingApp.iOS/VotingApp.iOS.csproj
@@ -125,7 +125,7 @@
     <Reference Include="Xamarin.iOS" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="3.4.0.1009999" />
+    <PackageReference Include="Xamarin.Forms" Version="3.4.0.1029999" />
     <PackageReference Include="Newtonsoft.Json">
       <Version>12.0.1</Version>
     </PackageReference>
@@ -133,13 +133,13 @@
       <Version>1.0.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.AppCenter.Crashes">
-      <Version>1.12.0</Version>
+      <Version>1.13.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.AppCenter.Analytics">
-      <Version>1.12.0</Version>
+      <Version>1.13.0</Version>
     </PackageReference>
     <PackageReference Include="Syncfusion.Xamarin.SfChart">
-      <Version>16.4.0.47</Version>
+      <Version>16.4.0.48</Version>
     </PackageReference>
     <PackageReference Include="AsyncAwaitBestPractices.MVVM">
       <Version>2.1.0</Version>

--- a/mobile/VotingApp/VotingApp/Models/GraphQL Models/GraphQLError.cs
+++ b/mobile/VotingApp/VotingApp/Models/GraphQL Models/GraphQLError.cs
@@ -6,11 +6,7 @@ namespace VotingApp
 {
     class GraphQLError
     {
-        public GraphQLError(string message, GraphQLLocation[] locations)
-        {
-            Message = message;
-            Locations = locations;
-        }
+        public GraphQLError(string message, GraphQLLocation[] locations) => (Message, Locations) = (message, locations);
 
         [JsonProperty("message")]
         public string Message { get; }

--- a/mobile/VotingApp/VotingApp/Models/GraphQL Models/GraphQLRequest.cs
+++ b/mobile/VotingApp/VotingApp/Models/GraphQL Models/GraphQLRequest.cs
@@ -4,11 +4,7 @@ namespace VotingApp
 {
     class GraphQLRequest
     {
-        public GraphQLRequest(string query, string variables = null)
-        {
-            Query = query;
-            Variables = variables;
-        }
+        public GraphQLRequest(string query, string variables = null) => (Query, Variables) = (query, variables);
 
         [JsonProperty("query")]
         public string Query { get; }

--- a/mobile/VotingApp/VotingApp/Models/GraphQL Models/GraphQLResponse.cs
+++ b/mobile/VotingApp/VotingApp/Models/GraphQL Models/GraphQLResponse.cs
@@ -4,16 +4,12 @@ namespace VotingApp
 {
     class GraphQLResponse<T>
     {
-        public GraphQLResponse(T data, GraphQLError[] errors)
-        {
-            Data = data;
-            Errors = errors;
-        }
+        public GraphQLResponse(T data, GraphQLError[] errors) => (Data, Errors) = (data, errors);
 
         [JsonProperty("data")]
-        public T Data { get; set; }
+        public T Data { get; }
 
         [JsonProperty("errors")]
-        public GraphQLError[] Errors { get; set; }
+        public GraphQLError[] Errors { get; }
     }
 }

--- a/mobile/VotingApp/VotingApp/Models/IncrementPointsDataResponse.cs
+++ b/mobile/VotingApp/VotingApp/Models/IncrementPointsDataResponse.cs
@@ -4,7 +4,9 @@ namespace VotingApp
 {
     class IncrementPointsDataResponse
     {
+        public IncrementPointsDataResponse(TeamScore teamScore) => TeamScore = teamScore;
+
         [JsonProperty("incrementPoints")]
-        public TeamScore TeamScore { get; set; }
+        public TeamScore TeamScore { get; }
     }
 }

--- a/mobile/VotingApp/VotingApp/Models/TeamsQueryDataResponse.cs
+++ b/mobile/VotingApp/VotingApp/Models/TeamsQueryDataResponse.cs
@@ -6,7 +6,9 @@ namespace VotingApp
 {
     class TeamsQueryDataResponse
     {
+        public TeamsQueryDataResponse(List<TeamScore> teams) => Teams = teams;
+
         [JsonProperty("teams")]
-        public List<TeamScore> Teams { get; set; }
+        public List<TeamScore> Teams { get; }
     }
 }

--- a/mobile/VotingApp/VotingApp/Settings/GraphQLSettings.cs
+++ b/mobile/VotingApp/VotingApp/Settings/GraphQLSettings.cs
@@ -1,13 +1,27 @@
 ﻿using System;
 
+using AsyncAwaitBestPractices;
+
 using Xamarin.Essentials;
 
 namespace VotingApp
 {
     abstract class GraphQLSettings
     {
+        #region Constant Fields
+        readonly static WeakEventManager<Uri> _uriChangedEventHandler = new WeakEventManager<Uri>();
+        #endregion
+
         #region Fields
         static Uri _uri;
+        #endregion
+
+        #region Events
+        public static event EventHandler<Uri> UriChanged
+        {
+            add => _uriChangedEventHandler.AddEventHandler(value);
+            remove => _uriChangedEventHandler.RemoveEventHandler(value);
+        }
         #endregion
 
         #region Properties
@@ -18,6 +32,7 @@ namespace VotingApp
             {
                 _uri = value;
                 Preferences.Set(nameof(Uri), value.ToString());
+                OnUriChanged(value);
             }
         }
 
@@ -26,6 +41,8 @@ namespace VotingApp
             get => Preferences.Get(nameof(ShouldUpdateChartAutomatically), true);
             set => Preferences.Set(nameof(ShouldUpdateChartAutomatically), value);
         }
+
+        static void OnUriChanged(Uri uri) => _uriChangedEventHandler.HandleEvent(null, uri, nameof(UriChanged));
         #endregion
     }
 }

--- a/mobile/VotingApp/VotingApp/VotingApp.csproj
+++ b/mobile/VotingApp/VotingApp/VotingApp.csproj
@@ -11,12 +11,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="3.4.0.1009999" />
+    <PackageReference Include="Xamarin.Forms" Version="3.4.0.1029999" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="Xamarin.Essentials" Version="1.0.1" />
-    <PackageReference Include="Microsoft.AppCenter.Crashes" Version="1.12.0" />
-    <PackageReference Include="Microsoft.AppCenter.Analytics" Version="1.12.0" />
-    <PackageReference Include="Syncfusion.Xamarin.SfChart" Version="16.4.0.47" />
+    <PackageReference Include="Microsoft.AppCenter.Crashes" Version="1.13.0" />
+    <PackageReference Include="Microsoft.AppCenter.Analytics" Version="1.13.0" />
+    <PackageReference Include="Syncfusion.Xamarin.SfChart" Version="16.4.0.48" />
     <PackageReference Include="AsyncAwaitBestPractices.MVVM" Version="2.1.0" />
     <PackageReference Include="Refit" Version="4.6.58" />
     <PackageReference Include="Polly" Version="6.1.2" />


### PR DESCRIPTION
This fix will automatically point the GraphQL queries to the new API Endpoint when the user changes the `GraphQL API Endpoint` setting on the Settings page.

Previously, the user would need to force-quit & restart the app for the change to take effect.